### PR TITLE
 Update Workflows + Add Defold API to LSP hover

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04,  target: linux,   platform: linux-x64, zip: x86_64-linux    }
-          - { os: macos-11,       target: darwin,  platform: darwin-x64, zip: x86_64-macos   }
-          - { os: macos-11,       target: darwin,  platform: darwin-arm64, zip: arm64-macos  }
+          - { os: ubuntu-22.04,  target: linux,   platform: linux-x64, zip: x86_64-linux    }
+          - { os: macos-13,       target: darwin,  platform: darwin-x64, zip: x86_64-macos   }
+          - { os: macos-13,       target: darwin,  platform: darwin-arm64, zip: arm64-macos  }
           - { os: windows-latest, target: windows, platform: win32-x64, zip: x86_64-win32    }
     runs-on: ${{ matrix.os }}
     steps:
@@ -99,12 +99,10 @@ jobs:
           rm -r bin 
           cd -
 
-          cd defold
-          7z -y a release.zip *
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: release
-          path: defold/release.zip
+          path: defold
       - name: Publish release assets
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           # Full name of the tarball asset
           PKG_NAME="${PKG_BASENAME}.zip"
 
-          7z -y a ${PKG_NAME} ${{ env.BIN_DIR }} main.lua debugger.lua LICENSE locale meta/template/ meta/spell/ script
+          7z -y a ${PKG_NAME} ${{ env.BIN_DIR }} main.lua debugger.lua LICENSE locale meta/template/ meta/spell/ script meta/3rd/Defold
 
           echo PKG_VERSION=${PKG_VERSION}             >> $GITHUB_OUTPUT
           echo PKG_BASENAME=${PKG_BASENAME}           >> $GITHUB_OUTPUT

--- a/defold/lsp-lua-language-server/plugins/share/config.json
+++ b/defold/lsp-lua-language-server/plugins/share/config.json
@@ -7,6 +7,12 @@
     "Lua": {
         "runtime": {
             "version": "Lua 5.1"
+        },
+        "workspace": {
+            "library": [
+                "${3rd}/Defold/library",
+                ".internal"
+            ]
         }
     },
     "window": {


### PR DESCRIPTION
Updating the workflow was a requirement of getting the artifacts to test the PR, which is why they're together.

### Workflows
One commit updates the workflows so they work.
`ubuntu-20.04` runner is [fully retired as of April 2025](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down)
`macos-11` runner was depreciated so long ago that [macos-12 was fully retired in December 2024](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/)
`upload-artifact@v2` was [depreciated in February of 2024](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).

Other than updating the runners to a new version, the only other change is that `upload-artifacts@v4` packages a path and zips it, so instead of the lines `cd defold` and  `7z -y a release.zip *`, we zip the defold path. Without this change, I was getting `release.zip` that contained `release.zip`

### LSP Hover
The first change is that the LSP's `meta/3rd/Defold` folder is zipped in the gitlab workflow so that the completions are bundled with the editor. The second change adds the `meta/3rd/Defold` and `.internal` folder as libraries to the LSP.

Adding the Defold library gives us this hovering `go.get_position()` for example:
![defold_hover](https://github.com/user-attachments/assets/13a3485e-c44f-4ca9-a55e-b6478b23a7af)

I had a hard time testing this PR because of how the editor adds the `config.json`, so here is a brief rundown of my method of testing it:
1. Download the workflow artifact `Release.zip` and extract it.
2. Start `lein run`
3. When the editor has loaded "Recent Projects", extract your OS's `.zip` from the `lsp-lua-language-server/plugins/{platform}.zip` to `{Defold src dir}/editor/tmp/unpack/{platform}/bin/lsp/lua/`
4. Copy `lsp-lua-language-server/plugins/share/config.json` to `{Defold src dir}/editor/tmp/unpack/{platform}/bin/lsp/lua/config.json`